### PR TITLE
Fix sender-side interleaving of same-protocol multi-frame messages

### DIFF
--- a/src/BroadcastManager.lua
+++ b/src/BroadcastManager.lua
@@ -82,19 +82,20 @@ function BroadcastManager:FillSendBuffer(inCombat)
 
     local toRequeue = {}
     local queue = self.dataMessageQueue
-    local message = queue:GetOldestRelevantMessage(inCombat)
+    local partiallySentIds = queue:GetPartiallySentIds()
+    local message = queue:GetOldestRelevantMessage(inCombat, partiallySentIds)
     AddMessage(message, frameHandler, toRequeue)
 
     while frameHandler:GetBytesFree() > 3 do
-        message = queue:GetNextRelevantEntry(inCombat)
+        message = queue:GetNextRelevantEntry(inCombat, partiallySentIds)
         if not AddMessage(message, frameHandler, toRequeue) then break end
     end
 
     local bytesFree = frameHandler:GetBytesFree()
     if bytesFree > 1 and bytesFree <= 3 then
-        message = queue:GetNextRelevantEntryWithExactSize(3, inCombat)
+        message = queue:GetNextRelevantEntryWithExactSize(3, inCombat, partiallySentIds)
         if not message then
-            message = queue:GetNextRelevantEntry(inCombat)
+            message = queue:GetNextRelevantEntry(inCombat, partiallySentIds)
         end
         AddMessage(message, frameHandler, toRequeue)
     end

--- a/src/messages/DataMessageBase.lua
+++ b/src/messages/DataMessageBase.lua
@@ -48,6 +48,14 @@ function DataMessageBase:ShouldDeleteQueuedMessages()
     return self.options.replaceQueuedMessages == true
 end
 
+function DataMessageBase:IsPartiallySent()
+    return false
+end
+
+function DataMessageBase:IsBlockedByPartiallySent(partiallySentIds)
+    return false
+end
+
 function DataMessageBase:ShouldRequeue()
     return false
 end

--- a/src/messages/FlexSizeDataMessage.lua
+++ b/src/messages/FlexSizeDataMessage.lua
@@ -55,6 +55,14 @@ function FlexSizeDataMessage:IsFullySent()
     return self.bytesSent == self.data:GetByteLength()
 end
 
+function FlexSizeDataMessage:IsPartiallySent()
+    return self.bytesSent > 0 and not self:IsFullySent()
+end
+
+function FlexSizeDataMessage:IsBlockedByPartiallySent(partiallySentIds)
+    return partiallySentIds and not self:IsPartiallySent() and partiallySentIds[self:GetId()] or false
+end
+
 function FlexSizeDataMessage:ShouldRequeue()
     return not self:IsFullySent()
 end


### PR DESCRIPTION
When two flex messages share the same protocol ID (sent with replaceQueuedMessages = false), their chunks can get interleaved across frames. This can happen in two ways:
1. Re-enqueueing a partially-sent message gives it a new queueId, making it appear "newest", so GetOldestRelevantMessage picks the other message next frame. The receiver then sees two first-chunks for the same id, the second overwrites the first's reassembly entry, and everything falls apart from there.
2. A different message from the current in-flight message is picked up from the queue because it has smaller size (for example, message 1 is in progress and has 70 bytes left and message 2 is queued but it is only 40 bytes), which also results in discarding transferred data and building a message using different messages' chunks

The fix: FillSendBuffer computes a set of protocol IDs that have partially-sent messages in the queue, and the dequeue methods skip fresh messages with those IDs. This forces at most one message per protocol to be in a partially transmitted state to ensure all chunks are delivered before we move on to the next one